### PR TITLE
RA-2088 Downgrades Newtonsoft Json package to version 9.0.1

### DIFF
--- a/src/SFA.DAS.Notifications.Api.Client/SFA.DAS.Notifications.Api.Client.csproj
+++ b/src/SFA.DAS.Notifications.Api.Client/SFA.DAS.Notifications.Api.Client.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="SFA.DAS.Http" Version="1.2.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="SFA.DAS.Http" Version="1.2.112" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
FAA cannot be upgraded to use version 10.x of Newtonsoft hence downgrading this dependency project to use version 9.0.1. 

Note: to keep impact to minimal only the client package is downgraded. 