### PR TITLE
Removed Obsolete attribute from ClientToken and added to AAD properties

### DIFF
--- a/src/SFA.DAS.Notifications.Api.Client.UnitTests/NotificationsApiClientConfigurationTests/AttributeTests.cs
+++ b/src/SFA.DAS.Notifications.Api.Client.UnitTests/NotificationsApiClientConfigurationTests/AttributeTests.cs
@@ -1,0 +1,27 @@
+using System;
+using FluentAssertions;
+using NUnit.Framework;
+using SFA.DAS.Notifications.Api.Client.Configuration;
+
+namespace SFA.DAS.Notifications.Api.Client.UnitTests.NotificationsApiClientConfigurationTests
+{
+    [TestFixture]
+    public class AttributeTests
+    {
+        [Test]
+        public void ClientTokenDoesNotHaveAnObsoleteAttribute()
+        {
+            typeof(NotificationsApiClientConfiguration).GetProperty("ClientToken").Should().NotBeDecoratedWith<ObsoleteAttribute>();
+        }
+
+
+        [TestCase("ClientId")]
+        [TestCase("ClientSecret")]
+        [TestCase("IdentifierUri")]
+        [TestCase("Tenant")]
+        public void AADPropertyHasObsoleteAttribute(string propertyName)
+        {
+            typeof(NotificationsApiClientConfiguration).GetProperty(propertyName).Should().BeDecoratedWith<ObsoleteAttribute>();
+        }
+    }
+}

--- a/src/SFA.DAS.Notifications.Api.Client.UnitTests/SFA.DAS.Notifications.Api.Client.UnitTests.csproj
+++ b/src/SFA.DAS.Notifications.Api.Client.UnitTests/SFA.DAS.Notifications.Api.Client.UnitTests.csproj
@@ -35,6 +35,10 @@
       <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FluentAssertions, Version=5.6.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a">
+      <HintPath>..\packages\FluentAssertions.5.6.0\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
@@ -60,6 +64,10 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -71,6 +79,7 @@
     <Compile Include="FakeResponseHandler.cs" />
     <Compile Include="NotificationApiClientTests\WhenISendAnSms.cs" />
     <Compile Include="NotificationApiClientTests\WhenISendAnEmail.cs" />
+    <Compile Include="NotificationsApiClientConfigurationTests\AttributeTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SFA.DAS.Notifications.Api.Client.UnitTests/packages.config
+++ b/src/SFA.DAS.Notifications.Api.Client.UnitTests/packages.config
@@ -1,10 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
+  <package id="FluentAssertions" version="5.6.0" targetFramework="net452" />
   <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net452" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.8" targetFramework="net45" />
   <package id="Moq" version="4.5.28" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NUnit" version="3.5.0" targetFramework="net45" />
   <package id="SFA.DAS.Http" version="1.2.112" targetFramework="net45" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net452" />
 </packages>

--- a/src/SFA.DAS.Notifications.Api.Client/Configuration/NotificationsApiClientConfiguration.cs
+++ b/src/SFA.DAS.Notifications.Api.Client/Configuration/NotificationsApiClientConfiguration.cs
@@ -5,12 +5,16 @@ namespace SFA.DAS.Notifications.Api.Client.Configuration
     public class NotificationsApiClientConfiguration : INotificationsApiClientConfiguration
     {
         public string ApiBaseUrl { get; set; }
+        
+        [Obsolete("Azure AD authentication is obsolete. Use JWT authentication.")]
         public string ClientId { get; set; }
+        [Obsolete("Azure AD authentication is obsolete. Use JWT authentication.")]
         public string ClientSecret { get; set; }
+        [Obsolete("Azure AD authentication is obsolete. Use JWT authentication.")]
         public string IdentifierUri { get; set; }
+        [Obsolete("Azure AD authentication is obsolete. Use JWT authentication.")]
         public string Tenant { get; set; }
-
-        [Obsolete("Jwt token usage is obsolete. Use Azure AD authentication.")]
+        
         public string ClientToken { get; set; }
     }
 }


### PR DESCRIPTION
As the notifications API no longer supports AAD for authentication, the Client package should no longer be warning about use of ClientToken, but should warn of use of the AAD properties instead.