### PR TITLE
Use SystemId to call alternate Gov Notify services.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,19 @@ Supported permissions are:
     SendSMS
 
 
+## Additional Gov Notify Services ##
+
+The API now supports multiple Gov Notify services. To use a different service, pass a SystemId with the email or SMS that matches the ServiceName in the configuration described below. If the system id is blank or not found in configuration then the default Apprenticeship Service api key will be used.
+
+To configure your service, add an element to the ConsumerConfiguration array inside `"NotifyServiceConfiguration"` in DAS Employer Config. This can be done via the build pipeline using the environment variable`GovNotifyConsumerConfiguration`
+
+```
+"ConsumerConfiguration": [
+    {
+      "ServiceName": "YourSystemId",
+      "ApiKey": "samplekey-11111111-1111-1111-1111-111111111111-22222222-2222-2222-2222-222222222222"
+    }
+  ]
+```
+
+The API Key should be a V2 API Key obtained from the Gov Notify portal.

--- a/src/SFA.DAS.Notifications.Api/Controllers/EmailController.cs
+++ b/src/SFA.DAS.Notifications.Api/Controllers/EmailController.cs
@@ -25,7 +25,8 @@ namespace SFA.DAS.Notifications.Api.Controllers
         [Authorize(Roles = "SendEmail")]
         public async Task<HttpResponseMessage> Post(Email notification)
         {
-            if (!string.IsNullOrEmpty(User.Identity.Name))
+            if (string.IsNullOrEmpty(notification.SystemId)
+                && !string.IsNullOrEmpty(User.Identity.Name))
             {
                 notification.SystemId = User.Identity.Name;
             }

--- a/src/SFA.DAS.Notifications.Api/Controllers/SmsController.cs
+++ b/src/SFA.DAS.Notifications.Api/Controllers/SmsController.cs
@@ -27,7 +27,8 @@ namespace SFA.DAS.Notifications.Api.Controllers
         [ApiAuthorize(Roles = "SendSMS")]
         public async Task<HttpResponseMessage> Post(Sms notification)
         {
-            if (!string.IsNullOrEmpty(User.Identity.Name))
+            if (string.IsNullOrEmpty(notification.SystemId)
+                && !string.IsNullOrEmpty(User.Identity.Name))
             {
                 notification.SystemId = User.Identity.Name;
             }

--- a/src/SFA.DAS.Notifications.Infrastructure.UnitTests/GovNotifyServiceCredentialTests/WhenCreatingFromV2ApiKey.cs
+++ b/src/SFA.DAS.Notifications.Infrastructure.UnitTests/GovNotifyServiceCredentialTests/WhenCreatingFromV2ApiKey.cs
@@ -1,0 +1,33 @@
+﻿using NUnit.Framework;
+using SFA.DAS.Notifications.Infrastructure.NotifyEmailService;
+
+namespace SFA.DAS.Notifications.Infrastructure.UnitTests.GovNotifyServiceCredentialTests
+{
+    public class WhenCreatingFromV2ApiKey
+    {
+        private const string V2ApiKey =
+            "samplekey-11111111-1111-1111-1111-111111111111-22222222-2222-2222-2222-222222222222";
+        private const string ServiceId = "11111111-1111-1111-1111-111111111111";
+        private const string ApiKey = "22222222-2222-2222-2222-222222222222";
+
+        private GovNotifyServiceCredentials _serviceCredentials;
+
+        [SetUp]
+        public void Arrange()
+        {
+            _serviceCredentials = GovNotifyServiceCredentials.FromV2ApiKey(V2ApiKey);
+        }
+
+        [Test]
+        public void ThenServiceIdShouldBeSet()
+        {
+            Assert.AreEqual(ServiceId, _serviceCredentials.ServiceId);
+        }
+
+        [Test]
+        public void ThenApiKeyShouldBeSet()
+        {
+            Assert.AreEqual(ApiKey, _serviceCredentials.ApiKey);
+        }
+    }
+}

--- a/src/SFA.DAS.Notifications.Infrastructure.UnitTests/NotifyEmailServiceTests/WhenSendingAnEmail.cs
+++ b/src/SFA.DAS.Notifications.Infrastructure.UnitTests/NotifyEmailServiceTests/WhenSendingAnEmail.cs
@@ -6,7 +6,7 @@ using SFA.DAS.Notifications.Domain.Entities;
 using SFA.DAS.Notifications.Infrastructure.ExecutionPolicies;
 using SFA.DAS.Notifications.Infrastructure.NotifyEmailService;
 
-namespace SFA.DAS.Notifications.Infrastructure.UnitTests.NotifyEmailServiceTests.NotifyEmailServiceTests
+namespace SFA.DAS.Notifications.Infrastructure.UnitTests.NotifyEmailServiceTests
 {
     public class WhenSendingAnEmail
     {
@@ -14,6 +14,7 @@ namespace SFA.DAS.Notifications.Infrastructure.UnitTests.NotifyEmailServiceTests
         private const string TemplateId = "81476cee-9863-40ee-8b18-33dcb898e9c9";
         private const string TokenKey = "Key1";
         private const string TokenValue = "Value1";
+        private const string SystemId = "TestSystem";
 
         private Mock<INotifyHttpClientWrapper> _httpClient;
         private NotifyEmailService.NotifyEmailService _service;
@@ -36,7 +37,8 @@ namespace SFA.DAS.Notifications.Infrastructure.UnitTests.NotifyEmailServiceTests
                 Tokens = new Dictionary<string, string>
                 {
                     { TokenKey, TokenValue }
-                }
+                },
+                SystemId = SystemId
             };
         }
 
@@ -83,6 +85,16 @@ namespace SFA.DAS.Notifications.Infrastructure.UnitTests.NotifyEmailServiceTests
 
             // Assert
             _httpClient.Verify(c => c.SendEmail(It.Is<NotifyMessage>(m => m.Personalisation != null)));
+        }
+
+        [Test]
+        public async Task ThenItShouldSendAMessageWithTheCorrectSystemId()
+        {
+            // Act
+            await _service.SendAsync(_email);
+
+            // Assert
+            _httpClient.Verify(c => c.SendEmail(It.Is<NotifyMessage>(m => m.SystemId == SystemId)));
         }
     }
 }

--- a/src/SFA.DAS.Notifications.Infrastructure.UnitTests/NotifyEmailServiceTests/WhenSendingAnSms.cs
+++ b/src/SFA.DAS.Notifications.Infrastructure.UnitTests/NotifyEmailServiceTests/WhenSendingAnSms.cs
@@ -6,7 +6,7 @@ using SFA.DAS.Notifications.Domain.Entities;
 using SFA.DAS.Notifications.Infrastructure.ExecutionPolicies;
 using SFA.DAS.Notifications.Infrastructure.NotifyEmailService;
 
-namespace SFA.DAS.Notifications.Infrastructure.UnitTests.NotifyEmailServiceTests.NotifyEmailServiceTests
+namespace SFA.DAS.Notifications.Infrastructure.UnitTests.NotifyEmailServiceTests
 {
     public class WhenSendingAnSms
     {
@@ -14,6 +14,7 @@ namespace SFA.DAS.Notifications.Infrastructure.UnitTests.NotifyEmailServiceTests
         private const string TemplateId = "81476cee-9863-40ee-8b18-33dcb898e9c9";
         private const string TokenKey = "Key1";
         private const string TokenValue = "Value1";
+        private const string SystemId = "TestSystem";
 
         private Mock<INotifyHttpClientWrapper> _httpClient;
         private NotifyEmailService.NotifySmsService _service;
@@ -36,7 +37,8 @@ namespace SFA.DAS.Notifications.Infrastructure.UnitTests.NotifyEmailServiceTests
                 Tokens = new Dictionary<string, string>
                 {
                     { TokenKey, TokenValue }
-                }
+                },
+                SystemId = SystemId
             };
         }
 
@@ -83,6 +85,16 @@ namespace SFA.DAS.Notifications.Infrastructure.UnitTests.NotifyEmailServiceTests
 
             // Assert
             _httpClient.Verify(c => c.SendSms(It.Is<NotifyMessage>(m => m.Personalisation != null)));
+        }
+
+        [Test]
+        public async Task ThenItShouldSendAMessageWithTheCorrectSystemId()
+        {
+            // Act
+            await _service.SendAsync(_sms);
+
+            // Assert
+            _httpClient.Verify(c => c.SendSms(It.Is<NotifyMessage>(m => m.SystemId == SystemId)));
         }
     }
 }

--- a/src/SFA.DAS.Notifications.Infrastructure.UnitTests/SFA.DAS.Notifications.Infrastructure.UnitTests.csproj
+++ b/src/SFA.DAS.Notifications.Infrastructure.UnitTests/SFA.DAS.Notifications.Infrastructure.UnitTests.csproj
@@ -62,6 +62,7 @@
     <Compile Include="ConfigurationTests\TemplateConfigurationServiceTests\TemplateConfigurationServiceTestBase.cs" />
     <Compile Include="ConfigurationTests\TemplateConfigurationServiceTests\WhenGettingAsync.cs" />
     <Compile Include="ConfigurationTests\TemplateConfigurationServiceTests\WhenGetting.cs" />
+    <Compile Include="GovNotifyServiceCredentialTests\WhenCreatingFromV2ApiKey.cs" />
     <Compile Include="NotifyEmailServiceTests\WhenSendingAnSms.cs" />
     <Compile Include="NotifyEmailServiceTests\WhenSendingAnEmail.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/SFA.DAS.Notifications.Infrastructure/Configuration/NotifyServiceConfiguration.cs
+++ b/src/SFA.DAS.Notifications.Infrastructure/Configuration/NotifyServiceConfiguration.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace SFA.DAS.Notifications.Infrastructure.Configuration
 {
     public class NotifyServiceConfiguration
@@ -5,5 +7,7 @@ namespace SFA.DAS.Notifications.Infrastructure.Configuration
         public string ApiBaseUrl { get; set; }
         public string ServiceId { get; set; }
         public string ApiKey { get; set; }
+
+        public List<NotifyServiceConsumerConfiguration> ConsumerConfiguration { get; set; }
     }
 }

--- a/src/SFA.DAS.Notifications.Infrastructure/Configuration/NotifyServiceConsumerConfiguration.cs
+++ b/src/SFA.DAS.Notifications.Infrastructure/Configuration/NotifyServiceConsumerConfiguration.cs
@@ -1,0 +1,9 @@
+
+namespace SFA.DAS.Notifications.Infrastructure.Configuration
+{
+    public class NotifyServiceConsumerConfiguration
+    {
+        public string ServiceName { get; set; }
+        public string ApiKey { get; set; }
+    }
+}

--- a/src/SFA.DAS.Notifications.Infrastructure/NotifyEmailService/GovNotifyServiceCredentials.cs
+++ b/src/SFA.DAS.Notifications.Infrastructure/NotifyEmailService/GovNotifyServiceCredentials.cs
@@ -1,0 +1,34 @@
+﻿using System.Configuration;
+
+namespace SFA.DAS.Notifications.Infrastructure.NotifyEmailService
+{
+    public class GovNotifyServiceCredentials
+    {
+        private const int ServiceIdStartPosition = 73;
+        private const int ServiceApiKeyStartPosition = 36;
+        private const int GuidLength = 36;
+
+        public string ServiceId { get; }
+
+        public string ApiKey { get; }
+
+        public GovNotifyServiceCredentials(string serviceId, string apiKey)
+        {
+            ServiceId = serviceId;
+            ApiKey = apiKey;
+        }
+
+        public static GovNotifyServiceCredentials FromV2ApiKey(string fromApiKey)
+        {
+            if (fromApiKey.Length < 74)
+            {
+                throw new ConfigurationErrorsException("The API Key provided is invalid. Please ensure you are using a v2 API Key that is not empty or null");
+            }
+
+            var serviceId = fromApiKey.Substring(fromApiKey.Length - ServiceIdStartPosition, GuidLength);
+            var apiKey = fromApiKey.Substring(fromApiKey.Length - ServiceApiKeyStartPosition, GuidLength);
+
+            return new GovNotifyServiceCredentials(serviceId, apiKey);
+        }
+    }
+}

--- a/src/SFA.DAS.Notifications.Infrastructure/NotifyEmailService/NotifyEmailService.cs
+++ b/src/SFA.DAS.Notifications.Infrastructure/NotifyEmailService/NotifyEmailService.cs
@@ -33,7 +33,8 @@ namespace SFA.DAS.Notifications.Infrastructure.NotifyEmailService
                 To = message.RecipientsAddress,
                 Template = message.TemplateId,
                 Personalisation = (message.Tokens ?? new Dictionary<string, string>()).ToDictionary(item => item.Key.ToLower(), item => item.Value),
-                Reference = message.Reference
+                Reference = message.Reference,
+                SystemId = message.SystemId
             };
 
             return _executionPolicy.ExecuteAsync(() => _clientWrapper.SendEmail(notifyMessage));

--- a/src/SFA.DAS.Notifications.Infrastructure/NotifyEmailService/NotifyMessage.cs
+++ b/src/SFA.DAS.Notifications.Infrastructure/NotifyEmailService/NotifyMessage.cs
@@ -13,5 +13,7 @@ namespace SFA.DAS.Notifications.Infrastructure.NotifyEmailService
         public Dictionary<string, string> Personalisation { get; set; }
         [JsonProperty(PropertyName = "reference")]
         public object Reference { get; set; }
+        [JsonProperty(PropertyName = "systemId")]
+        public string SystemId { get; set; }
     }
 }

--- a/src/SFA.DAS.Notifications.Infrastructure/NotifyEmailService/NotifySmsService.cs
+++ b/src/SFA.DAS.Notifications.Infrastructure/NotifyEmailService/NotifySmsService.cs
@@ -31,6 +31,7 @@ namespace SFA.DAS.Notifications.Infrastructure.NotifyEmailService
                 To = message.RecipientsNumber,
                 Template = message.TemplateId,
                 Personalisation = (message.Tokens ?? new Dictionary<string, string>()).ToDictionary(item => item.Key.ToLower(), item => item.Value),
+                SystemId = message.SystemId
             };
 
             return _executionPolicy.ExecuteAsync(() => _httpClientWrapper.SendSms(notifyMessage));

--- a/src/SFA.DAS.Notifications.Infrastructure/SFA.DAS.Notifications.Infrastructure.csproj
+++ b/src/SFA.DAS.Notifications.Infrastructure/SFA.DAS.Notifications.Infrastructure.csproj
@@ -149,6 +149,7 @@
     <Compile Include="ExecutionPolicies\SendMessageExecutionPolicy.cs" />
     <Compile Include="LocalEmailService\LocalEmailService.cs" />
     <Compile Include="NotifyEmailService\GovNotifyPayload.cs" />
+    <Compile Include="NotifyEmailService\GovNotifyServiceCredentials.cs" />
     <Compile Include="NotifyEmailService\JwtTokenUtility.cs" />
     <Compile Include="NotifyEmailService\NotifyHttpClientWrapper.cs" />
     <Compile Include="NotifyEmailService\NotifyEmailService.cs" />

--- a/src/SFA.DAS.Notifications.Infrastructure/SFA.DAS.Notifications.Infrastructure.csproj
+++ b/src/SFA.DAS.Notifications.Infrastructure/SFA.DAS.Notifications.Infrastructure.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Configuration\AzureServiceBusMessageServiceConfiguration.cs" />
     <Compile Include="Configuration\NotificationsStorageConfiguration.cs" />
     <Compile Include="Configuration\NotificationServiceConfiguration.cs" />
+    <Compile Include="Configuration\NotifyServiceConsumerConfiguration.cs" />
     <Compile Include="Configuration\NotifyServiceConfiguration.cs" />
     <Compile Include="Configuration\SmtpConfiguration.cs" />
     <Compile Include="Configuration\TemplateConfigurationService.cs" />


### PR DESCRIPTION
Changed the API to pass SystemId through for both Email and SMS, and changed infrastructure service code to check the SystemId against configuration for Notify service calls. If SystemId is not found in configuration then default Service/API keys will be used, otherwise the required API key will be extracted and used. Note that the new API keys should be valid V2 keys - see README.md.

Corresponding config change https://github.com/SkillsFundingAgency/das-employer-config/tree/TLWP-568-Add-notify-api-key-list-to_notifications - a PR will be created once this one has been approved.