### PR TITLE
switch over which endpoint performs outbox cleanup

### DIFF
--- a/src/SFA.DAS.Notifications.Api/StartupExtensions/NServiceBusStartUp.cs
+++ b/src/SFA.DAS.Notifications.Api/StartupExtensions/NServiceBusStartUp.cs
@@ -24,7 +24,7 @@ namespace SFA.DAS.Notifications.Api.StartupExtensions
                 .UseInstallers()
                 .UseMessageConventions()
                 .UseNewtonsoftJsonSerializer()
-                .UseOutbox(true)
+                .UseOutbox()
                 .UseServicesBuilder(serviceProvider)
                 .UseSqlServerPersistence(() => new SqlConnection(configuration["DatabaseConnectionString"]))
                 .UseUnitOfWork()

--- a/src/SFA.DAS.Notifications.MessageHandlers/Startup/NServiceBusStartup.cs
+++ b/src/SFA.DAS.Notifications.MessageHandlers/Startup/NServiceBusStartup.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Azure.ServiceBus.Primitives;
+﻿using System.Data.Common;
+using Microsoft.Azure.ServiceBus.Primitives;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NServiceBus;
@@ -12,7 +13,6 @@ using SFA.DAS.NServiceBus.Hosting;
 using SFA.DAS.NServiceBus.SqlServer.Configuration;
 using SFA.DAS.UnitOfWork.NServiceBus.Configuration;
 using StructureMap;
-using System.Data.Common;
 
 namespace SFA.DAS.Notifications.MessageHandlers.Startup
 {
@@ -34,7 +34,7 @@ namespace SFA.DAS.Notifications.MessageHandlers.Startup
                         .UseMessageConventions()
                         .UseNewtonsoftJsonSerializer()
                         .UseNLogFactory()
-                        .UseOutbox()
+                        .UseOutbox(true)
                         .UseSqlServerPersistence(() => container.GetInstance<DbConnection>())
                         .UseStructureMapBuilder(container)
                         .UseUnitOfWork();


### PR DESCRIPTION
This is because within NServicebus package code there is logic which says to not initiate the Outbox processes on SendOnly endpoints. The api has been configured as a send only endpoint. Cleanup has not running since